### PR TITLE
FIxed error when json_csrf tries to strip nil

### DIFF
--- a/lib/rack/protection/json_csrf.rb
+++ b/lib/rack/protection/json_csrf.rb
@@ -15,7 +15,7 @@ module Rack
 
       def call(env)
         status, headers, body = app.call(env)
-        if headers['Content-Type'].to_s.split(';', 2).first.strip == 'application/json'
+        if headers['Content-Type'].to_s.split(';', 2).first =~ /^\s*application\/json\s*$/
           result = react(env) if referrer(env) != Request.new(env).host
         end
         result or [status, headers, body]

--- a/spec/json_csrf_spec.rb
+++ b/spec/json_csrf_spec.rb
@@ -20,4 +20,13 @@ describe Rack::Protection::JsonCsrf do
       get('/', {}).should be_ok
     end
   end
+
+  describe 'not json response' do
+
+    it "accepts get requests with 304 headers" do
+      mock_app { |e| [304, {}, []]}
+      get('/', {}).status.should == 304
+    end
+
+  end
 end


### PR DESCRIPTION
The json_csrf protection makes an assumption that the response headers containt a Content-Type.  No Content-Type should be sent if the is status is 1xx, 204 or 304.  Any responses with those status codes cause the json_csrf protection the to raise a NoMethodError

NoMethodError:
       undefined method `strip' for nil:NilClass
     # ./lib/rack/protection/json_csrf.rb:18:in`call'

From http://tools.ietf.org/html/rfc2616#section-10.3.5 regarding 304 status codes

> If the conditional GET used a strong cache validator (see section
> 13.3.3), the response SHOULD NOT include other entity-headers.
> Otherwise (i.e., the conditional GET used a weak validator), the
> response MUST NOT include other entity-headers; this prevents
> inconsistencies between cached entity-bodies and updated headers.
