### PR TITLE
Add parens for 'Ambiguous first argument' warnings in jruby

### DIFF
--- a/lib/rack/protection/ip_spoofing.rb
+++ b/lib/rack/protection/ip_spoofing.rb
@@ -13,7 +13,7 @@ module Rack
 
       def accepts?(env)
         return true unless env.include? 'HTTP_X_FORWARDED_FOR'
-        ips = env['HTTP_X_FORWARDED_FOR'].split /\s*,\s*/
+        ips = env['HTTP_X_FORWARDED_FOR'].split(/\s*,\s*/)
         return false if env.include? 'HTTP_CLIENT_IP' and not ips.include? env['HTTP_CLIENT_IP']
         return false if env.include? 'HTTP_X_REAL_IP' and not ips.include? env['HTTP_X_REAL_IP']
         true

--- a/lib/rack/protection/path_traversal.rb
+++ b/lib/rack/protection/path_traversal.rb
@@ -22,7 +22,7 @@ module Rack
         return cleanup("/" << path)[1..-1] unless path[0] == ?/
         escaped = ::File.expand_path path.gsub('%2e', '.').gsub('%2f', '/')
         escaped << '/' if escaped[-1] != ?/ and path =~ /\/\.{0,2}$/
-        escaped.gsub /\/\/+/, '/'
+        escaped.gsub(/\/\/+/, '/')
       end
     end
   end


### PR DESCRIPTION
Fixes this and is otherwise harmless:

```
/home/david/.gem/jruby/1.8/gems/rack-protection-1.1.0/lib/rack/protection/ip_spoofing.rb:16 warning: Ambiguous first argument; make sure.
/home/david/.gem/jruby/1.8/gems/rack-protection-1.1.0/lib/rack/protection/path_traversal.rb:25 warning: Ambiguous first argument; make sure.
```
