### PR TITLE
Show warnings for JsonCsrf attacks

### DIFF
--- a/lib/rack/protection/json_csrf.rb
+++ b/lib/rack/protection/json_csrf.rb
@@ -16,7 +16,10 @@ module Rack
       def call(env)
         status, headers, body = app.call(env)
         if headers['Content-Type'].to_s.split(';', 2).first =~ /^\s*application\/json\s*$/
-          result = react(env) if referrer(env) != Request.new(env).host
+          if referrer(env) != Request.new(env).host
+            result = react(env)
+            warn env, "attack prevented by #{self.class}"
+          end
         end
         result or [status, headers, body]
       end


### PR DESCRIPTION
Since the `JsonCsrf` middleware overrides the `call` method, the default
warning is never displayed. I couldn't figure out why sinatra was
returning a 403 for CORS and JSONP requests, tracked it down to this.
