### PR TITLE
Path traversal protection should allow empty segments

### DIFF
--- a/lib/rack/protection/path_traversal.rb
+++ b/lib/rack/protection/path_traversal.rb
@@ -23,11 +23,11 @@ module Rack
         unescaped = path.gsub('%2e', '.').gsub('%2f', '/')
 
         unescaped.split('/').each do |part|
-          next if part.empty? or part == '.'
+          next if part == '.'
           part == '..' ? parts.pop : parts << part
         end
 
-        cleaned = '/' << parts.join('/')
+        cleaned = parts.join('/')
         cleaned << '/' if parts.any? and unescaped =~ /\/\.{0,2}$/
         cleaned
       end


### PR DESCRIPTION
I ran into some trouble with your path traversal protection because it disallows empty segments in the url. Specifically, "http://mysite.com/http://someothersite.com" was being translated to "http://mysite.com/http:/someothersite.com". (Yes, believe it or not, the former is a valid url.)

I don't see any danger to allowing empty segments, though I recognize that there might be a danger that I don't immediately guess at. Also, according to RFC3986 sec 3.3, empty segments should be allowed. (Not that an RFC is the best reason for changing it, but hey...)
