### PR TITLE
Do not add a / to empty path in 'path_traversal'

### DIFF
--- a/lib/rack/protection/path_traversal.rb
+++ b/lib/rack/protection/path_traversal.rb
@@ -12,7 +12,7 @@ module Rack
     class PathTraversal < Base
       def call(env)
         path_was         = env["PATH_INFO"]
-        env["PATH_INFO"] = cleanup path_was if path_was
+        env["PATH_INFO"] = cleanup path_was if path_was && !path_was.empty?
         app.call env
       ensure
         env["PATH_INFO"] = path_was


### PR DESCRIPTION
`path_traversal` should not change empty path to '/' because it breaks this kind of sinatra routing :

``` ruby
get '' do
  redirect to('/')
end
```
