### PR TITLE
allow cache-breaker params in EscapedParams

### DIFF
--- a/lib/rack/protection/escaped_params.rb
+++ b/lib/rack/protection/escaped_params.rb
@@ -66,7 +66,7 @@ module Rack
         when Hash   then escape_hash(object)
         when Array  then object.map { |o| escape(o) }
         when String then escape_string(object)
-        else raise ArgumentError, "cannot escape #{object.inspect}"
+        else nil
         end
       end
 

--- a/spec/escaped_params_spec.rb
+++ b/spec/escaped_params_spec.rb
@@ -30,5 +30,15 @@ describe Rack::Protection::EscapedParams do
       get '/', :foo => {:bar => "<bar>"}
       body.should == '&lt;bar&gt;'
     end
+
+    it 'leaves cache-breaker params untouched' do
+      mock_app do |env|
+        request = Rack::Request.new(env)
+        [200, {'Content-Type' => 'text/plain'}, ['hi']]
+      end
+
+      get '/?95df8d9bf5237ad08df3115ee74dcb10'
+      body.should == 'hi'
+    end
   end
 end


### PR DESCRIPTION
EscapedParams was raising exceptions on URLs with cache-breakers.  After giving it some thought, I couldn't think of why anything but a String, Array or Hash would be passed through.  So I've removed the ArgumentError exception raise and am instead returning nil which allows the parameter to pass through properly.
