### PR TITLE
Don't choke on requests that end up without a content-type header

### DIFF
--- a/lib/rack/protection/base.rb
+++ b/lib/rack/protection/base.rb
@@ -98,8 +98,16 @@ module Rack
       alias default_reaction deny
 
       def html?(headers)
-        type = headers.detect { |k,v| k.downcase == 'content-type' }.last[/^\w+\/\w+/]
-        type == 'text/html' or type == 'application/xhtml'
+        if type = headers.detect { |k,v| k.downcase == 'content-type' }
+          case type.last[/^\w+\/\w+/]
+          when 'text/html', 'application/xhtml'
+            true
+          else
+            false
+          end
+        else
+          false
+        end
       end
     end
   end

--- a/spec/protection_spec.rb
+++ b/spec/protection_spec.rb
@@ -17,4 +17,21 @@ describe Rack::Protection do
     get '/', {}, 'rack.session' => session, 'HTTP_FOO' => 'BAR'
     session.should be_empty
   end
+
+  describe "#html?" do
+    context "given an appropriate content-type header" do
+      subject { Rack::Protection::Base.new(nil).html?({'content-type' => "text/html"}) }
+      it { should be_true }
+    end
+
+    context "given an inappropriate content-type header" do
+      subject { Rack::Protection::Base.new(nil).html?({'content-type' => "image/gif"}) }
+      it { should be_false }
+    end
+
+    context "given no content-type header" do
+      subject { Rack::Protection::Base.new(nil).html?({}) }
+      it { should be_false }
+    end
+  end
 end


### PR DESCRIPTION
Sinatra can send responses without content-type headers. rack-protection blows up on them. This fixes that.
