### PR TITLE
Feature/report reaction

### DIFF
--- a/lib/rack/protection/base.rb
+++ b/lib/rack/protection/base.rb
@@ -11,6 +11,7 @@ module Rack
         :message     => 'Forbidden',       :encryptor => Digest::SHA1,
         :session_key => 'rack.session',    :status    => 403,
         :allow_empty_referrer => true,
+        :report_key           => "protection.failed",
         :html_types           => %w[text/html application/xhtml]
       }
 
@@ -61,6 +62,10 @@ module Rack
 
       def deny(env)
         [options[:status], {'Content-Type' => 'text/plain'}, [options[:message]]]
+      end
+
+      def report(env)
+        env[options[:report_key]] = true
       end
 
       def session?(env)

--- a/spec/protection_spec.rb
+++ b/spec/protection_spec.rb
@@ -18,6 +18,18 @@ describe Rack::Protection do
     session.should be_empty
   end
 
+  it 'passes errors through if :reaction => :report is used' do
+    mock_app do
+      use Rack::Protection, :reaction => :report
+      run proc { |e| [200, {'Content-Type' => 'text/plain'}, [e["protection.failed"].to_s]] }
+    end
+
+    session = {:foo => :bar}
+    post('/', {}, 'rack.session' => session, 'HTTP_ORIGIN' => 'http://malicious.com')
+    last_response.should be_ok
+    body.should == "true"
+  end
+
   describe "#html?" do
     context "given an appropriate content-type header" do
       subject { Rack::Protection::Base.new(nil).html? 'content-type' => "text/html" }


### PR DESCRIPTION
This pull requests implements a new style of reaction: report. Instead of denying the request immediately, the middleware only reports the status of its check. This allows the application to handle the request based on that info.

This comes in handy when someone wants to exclude certain routes from checks, e.g.:
https://github.com/padrino/padrino-framework/issues/893#issuecomment-13808244

This is intended to be used on single middlewares, e.g.:

```
use Rack::Protection::AuthenticityToken,
       :reaction => :report,
       :report_key => 'rack.protection.csrf.status'
```
