### PR TITLE
Fix PathTraversal to leave encoding of PATH_INFO unchanged

### DIFF
--- a/lib/rack/protection/path_traversal.rb
+++ b/lib/rack/protection/path_traversal.rb
@@ -19,16 +19,27 @@ module Rack
       end
 
       def cleanup(path)
-        parts     = []
-        unescaped = path.gsub(/%2e/i, '.').gsub(/%2f/i, '/')
+        if path.respond_to?(:encoding)
+          # Ruby 1.9+ M17N
+          encoding = path.encoding
+          dot   = '.'.encode(encoding)
+          slash = '/'.encode(encoding)
+        else
+          # Ruby 1.8
+          dot   = '.'
+          slash = '/'
+        end
 
-        unescaped.split('/').each do |part|
-          next if part.empty? or part == '.'
+        parts     = []
+        unescaped = path.gsub(/%2e/i, dot).gsub(/%2f/i, slash)
+
+        unescaped.split(slash).each do |part|
+          next if part.empty? or part == dot
           part == '..' ? parts.pop : parts << part
         end
 
-        cleaned = '/' << parts.join('/')
-        cleaned << '/' if parts.any? and unescaped =~ /\/\.{0,2}$/
+        cleaned = slash + parts.join(slash)
+        cleaned << slash if parts.any? and unescaped =~ %r{/\.{0,2}$}
         cleaned
       end
     end

--- a/spec/path_traversal_spec.rb
+++ b/spec/path_traversal_spec.rb
@@ -25,4 +25,17 @@ describe Rack::Protection::PathTraversal do
       app.call({}).should be == 42
     end
   end
+
+  if "".respond_to?(:encoding)  # Ruby 1.9+ M17N
+    context "PATH_INFO's encoding" do
+      before do
+        @app = Rack::Protection::PathTraversal.new(proc { |e| [200, {'Content-Type' => 'text/plain'}, [e['PATH_INFO'].encoding.to_s]] })
+      end
+
+      it 'should remain unchanged as ASCII-8BIT' do
+        body = @app.call({ 'PATH_INFO' => '/'.encode('ASCII-8BIT') })[2][0]
+        body.should == 'ASCII-8BIT'
+      end
+    end
+  end
 end


### PR DESCRIPTION
In current implementation, PathTraversal#cleanup method changes encoding of `env['PATH_INFO']` to `US-ASCII` (script default encoding) from `ASCII-8BIT` on Ruby 1.9.x.  (Ruby 2.0+ is safe)
Because `US-ASCII` is not 8bit clean, that behavior breaks some modules (such as [http_router](https://github.com/joshbuddy/http_router) ) when we access URLs with non-latin characters.

So I wrote the patch encoding in Ruby 1.9+ aware.

Also dayflower@7875ec5 commit is attached to this pull-request, in which escape chars in captals (eg. `%2E`) avoidance is fixed.
