### PR TITLE
Implemented an authenticity_param option on AuthenticityToken

### DIFF
--- a/lib/rack/protection/authenticity_token.rb
+++ b/lib/rack/protection/authenticity_token.rb
@@ -11,13 +11,20 @@ module Rack
     # included in the session.
     #
     # Compatible with Rails and rack-csrf.
+    #
+    # Options:
+    #
+    # authenticity_param: Defines the param's name that should contain the token on a request.
+    #
     class AuthenticityToken < Base
+      default_options :authenticity_param => 'authenticity_token'
+
       def accepts?(env)
         return true if safe? env
         session = session env
         token   = session[:csrf] ||= session['_csrf_token'] || random_string
         env['HTTP_X_CSRF_TOKEN'] == token or
-          Request.new(env).params['authenticity_token'] == token
+          Request.new(env).params[options[:authenticity_param]] == token
       end
     end
   end

--- a/spec/authenticity_token_spec.rb
+++ b/spec/authenticity_token_spec.rb
@@ -30,4 +30,14 @@ describe Rack::Protection::AuthenticityToken do
   it "prevents ajax requests without a valid token" do
     post('/', {}, "HTTP_X_REQUESTED_WITH" => "XMLHttpRequest").should_not be_ok
   end
+
+  it "allows for a custom authenticity token param" do
+    mock_app do
+      use Rack::Protection::AuthenticityToken, :authenticity_param => 'csrf_param'
+      run proc { |e| [200, {'Content-Type' => 'text/plain'}, ['hi']] }
+    end
+
+    post('/', {"csrf_param" => "a"}, 'rack.session' => {:csrf => "a"})
+    last_response.should be_ok
+  end
 end


### PR DESCRIPTION
Hi,

I've implemented an `:authenticity_param` option on the `AuthenticityToken` protection to allow for a different param name to be sent/expected by the application that uses it.

It provides some flexibility for users that would like to use a different naming convention on their form data.

The same could be applied for the header `X-CSRF-TOKEN` if you consider it necessary.

Hope you find it useful,
Darío
