### PR TITLE
Add instrumentation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,11 @@ Prevented by:
 
     gem install rack-protection
 
+# Instrumentation
+
+Instrumentation is enabled by passing in an instrumenter as an option.
+```
+use Rack::Protection, instrumenter: ActiveSupport::Notifications
+```
+
+The instrumenter is passed a namespace (String) and environment (Hash). The namespace is 'rack.protection' and the attack type can be obtained from the environment key 'rack.protection.attack'.

--- a/lib/rack/protection/base.rb
+++ b/lib/rack/protection/base.rb
@@ -44,6 +44,7 @@ module Rack
       def call(env)
         unless accepts? env
           warn env, "attack prevented by #{self.class}"
+          instrument env
           result = react env
         end
         result or app.call(env)
@@ -58,6 +59,12 @@ module Rack
         return unless options[:logging]
         l = options[:logger] || env['rack.logger'] || ::Logger.new(env['rack.errors'])
         l.warn(message)
+      end
+
+      def instrument(env)
+        return unless i = options[:instrumenter]
+        env['rack.protection.attack'] = self.class.name.split('::').last.downcase
+        i.instrument('rack.protection', env)
       end
 
       def deny(env)

--- a/spec/protection_spec.rb
+++ b/spec/protection_spec.rb
@@ -46,4 +46,25 @@ describe Rack::Protection do
       it { should be_false }
     end
   end
+
+  describe "#instrument" do
+    let(:env) { { 'rack.protection.attack' => 'base' } }
+    let(:instrumenter) { double('Instrumenter') }
+
+    after do
+      app.instrument(env)
+    end
+
+    context 'with an instrumenter specified' do
+      let(:app) { Rack::Protection::Base.new(nil, :instrumenter => instrumenter) }
+
+      it { instrumenter.should_receive(:instrument).with('rack.protection', env) }
+    end
+
+    context 'with no instrumenter specified' do
+      let(:app) { Rack::Protection::Base.new(nil) }
+
+      it { instrumenter.should_not_receive(:instrument) }
+    end
+  end
 end


### PR DESCRIPTION
We have been using it in production to track influxes in blocked requests. It was also important when we first started using rack-protection to see if maybe we were blocking a high number of legit users. 

Here is an example graphite graph you can produce:

![198 199 69](https://f.cloud.github.com/assets/245680/947923/72521aea-035d-11e3-966b-451572b97852.png)
