### PR TITLE
ensure Rack::Protection::Base#random_string always outputs 32 characters

### DIFF
--- a/lib/rack/protection/base.rb
+++ b/lib/rack/protection/base.rb
@@ -99,7 +99,7 @@ module Rack
       end
 
       def random_string(secure = defined? SecureRandom)
-        secure ? SecureRandom.hex(32) : "%032x" % rand(2**128-1)
+        secure ? SecureRandom.hex(16) : "%032x" % rand(2**128-1)
       rescue NotImplementedError
         random_string false
       end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -1,0 +1,9 @@
+require File.expand_path('../spec_helper.rb', __FILE__)
+
+describe Rack::Protection::Base do
+  describe "#random_string" do
+    it "outputs a string of 32 characters" do
+      described_class.new(lambda {}).random_string.length.should == 32
+    end
+  end
+end


### PR DESCRIPTION
Prior to this commit, authenticity tokens would be either 32 or 64 characters long, depending on the presence of SecureRandom in the environment.

This changes `Rack::Protection::Base#random_string` to always output strings of 32 characters, ensuring that generated authenticity tokens will always have the same length (whether we're using `SecureRandom.hex` or `Kernel.rand`).

(See [here](https://github.com/rkh/rack-protection/pull/68#issuecomment-23970508) for more discussion.)
