### PR TITLE
Ignore changing Accept-Encoding header, fixes #56

### DIFF
--- a/lib/rack/protection/session_hijacking.rb
+++ b/lib/rack/protection/session_hijacking.rb
@@ -9,12 +9,12 @@ module Rack
     #
     # Tracks request properties like the user agent in the session and empties
     # the session if those properties change. This essentially prevents attacks
-    # from Firesheep. Since all headers taken into consideration might be
-    # spoofed, too, this will not prevent all hijacking attempts.
+    # from Firesheep. Since all headers taken into consideration can be
+    # spoofed, too, this will not prevent determined hijacking attempts.
     class SessionHijacking < Base
       default_reaction :drop_session
       default_options :tracking_key => :tracking, :encrypt_tracking => true,
-        :track => %w[HTTP_USER_AGENT HTTP_ACCEPT_ENCODING HTTP_ACCEPT_LANGUAGE]
+        :track => %w[HTTP_USER_AGENT HTTP_ACCEPT_LANGUAGE]
 
       def accepts?(env)
         session = session env

--- a/spec/session_hijacking_spec.rb
+++ b/spec/session_hijacking_spec.rb
@@ -17,11 +17,12 @@ describe Rack::Protection::SessionHijacking do
     session.should be_empty
   end
 
-  it "denies requests with a changing Accept-Encoding header" do
+  it "accepts requests with a changing Accept-Encoding header" do
+    # this is tested because previously it led to clearing the session
     session = {:foo => :bar}
     get '/', {}, 'rack.session' => session, 'HTTP_ACCEPT_ENCODING' => 'a'
     get '/', {}, 'rack.session' => session, 'HTTP_ACCEPT_ENCODING' => 'b'
-    session.should be_empty
+    session.should_not be_empty
   end
 
   it "denies requests with a changing Accept-Language header" do


### PR DESCRIPTION
In this pull request, I've done the bare minimum changes to fix issue #56 when it comes to `<video>` and `<audio>` tags -- removed tracking of the Accept-Encoding header.

But as I stated in the thread on that issue, in my opinion this whole SessionHijacking protection is ill-advised, and I'd like to suggest removing it. It is **trivial** for an attacker to circumvent, and prone to other false positives in the future (there's no telling if a normally operating browser decides to prefer other languages for different URLs or different types of media). Also, browser are updated frequently and that changes the User-Agent string, effectively logging users out of any sites using this protection, even if the login isn't supposed to expire in months.
