### PR TITLE
clarify reaction warning, test it

### DIFF
--- a/lib/rack/protection/base.rb
+++ b/lib/rack/protection/base.rb
@@ -43,7 +43,6 @@ module Rack
 
       def call(env)
         unless accepts? env
-          warn env, "attack prevented by #{self.class}"
           instrument env
           result = react env
         end
@@ -68,10 +67,12 @@ module Rack
       end
 
       def deny(env)
+        warn env, "attack prevented by #{self.class}"
         [options[:status], {'Content-Type' => 'text/plain'}, [options[:message]]]
       end
 
       def report(env)
+        warn env, "attack reported by #{self.class}"
         env[options[:report_key]] = true
       end
 


### PR DESCRIPTION
Rack-protection tends to write misleading warnings to application log if a custom reaction is specified.

If I set `:reaction => :report` it still writes `attack prevented by Rack::Protection::RemoteToken` though it is not prevented, it is passed to the application with `options[:report_key]` flag.

The more, if I set `:reaction => :special`, rack-protection calls my special helper but still says that the attack was prevented.

I suggest to warn "prevented" when reaction reaches `#deny`, warn "reported" if reaction was to `#report` and do nothing if a custom method is used as reaction.
