### PR TITLE
Dont remove tempfile params, warn when dropping params

### DIFF
--- a/spec/escaped_params_spec.rb
+++ b/spec/escaped_params_spec.rb
@@ -39,5 +39,25 @@ describe Rack::Protection::EscapedParams do
       get '/?95df8d9bf5237ad08df3115ee74dcb10'
       body.should == 'hi'
     end
+
+    it 'leaves TempFiles untouched' do
+      mock_app do |env|
+        request = Rack::Request.new(env)
+        [200, {'Content-Type' => 'text/plain'}, [request.params['file'][:filename] + "\n" + \
+                                                 request.params['file'][:tempfile].read + "\n" + \
+                                                 request.params['other']]]
+      end
+
+      temp_file = File.open('_escaped_params_tmp_file', 'w')
+      begin
+        temp_file.write('hello world')
+        temp_file.close
+
+        post '/', :file => Rack::Test::UploadedFile.new(temp_file.path), :other => '<bar>'
+        body.should == "_escaped_params_tmp_file\nhello world\n&lt;bar&gt;"
+      ensure
+        File.unlink(temp_file.path)
+      end
+    end
   end
 end


### PR DESCRIPTION
Per issue #90, when params are not of the types string, array or hash,
the values were being silently dropped.

This commit adds:
* warning when dropping unhandled parameter types
* Explicitly handling and ignoring Tempfile objects