### PR TITLE
Adds ability to allow or deny being embedded based on the referrer domain

### DIFF
--- a/lib/rack/protection/frame_options.rb
+++ b/lib/rack/protection/frame_options.rb
@@ -17,7 +17,8 @@ module Rack
     #                 frame. Use :deny to forbid any embedding, :sameorigin
     #                 to allow embedding from the same origin (default).
     class FrameOptions < Base
-      default_options :frame_options => :sameorigin
+      default_options :frame_options => :sameorigin,
+                      :allow_if => nil
 
       def frame_options
         @frame_options ||= begin

--- a/lib/rack/protection/frame_options.rb
+++ b/lib/rack/protection/frame_options.rb
@@ -28,9 +28,15 @@ module Rack
         end
       end
 
+      def allow_specific_domain(env)
+        return nil unless options[:allow_if].is_a? Proc
+        referrer_domain = env["HTTP_REFERER"].scan(%r(http://(.+?)[\?/])).flatten.first
+        options[:allow_if].call(referrer_domain) ? "" : "DENY"
+      end
+
       def call(env)
-        status, headers, body        = @app.call(env)
-        headers['X-Frame-Options'] ||= frame_options if html? headers
+        status, headers, body = @app.call(env)
+        headers['X-Frame-Options'] ||= allow_specific_domain(env) || frame_options if html? headers
         [status, headers, body]
       end
     end

--- a/spec/lib/rack/protection/frame_options_spec.rb
+++ b/spec/lib/rack/protection/frame_options_spec.rb
@@ -34,4 +34,16 @@ describe Rack::Protection::FrameOptions do
     mock_app with_headers("X-Frame-Options" => "allow")
     expect(get('/', {}, 'wants' => 'text/html').headers["X-Frame-Options"]).to eq("allow")
   end
+
+  it 'should allow based on specific domain' do
+    mock_app do
+      use Rack::Protection::FrameOptions, :allow_if => ->(domain){
+        domain == 'google.com'
+      }
+      run DummyApp
+    end
+
+    expect(get('/', {}, 'wants' => 'text/html').headers["X-Frame-Options"]).to eq("")
+  end
+
 end

--- a/spec/lib/rack/protection/frame_options_spec.rb
+++ b/spec/lib/rack/protection/frame_options_spec.rb
@@ -37,7 +37,7 @@ describe Rack::Protection::FrameOptions do
 
   it 'should allow based on specific domain' do
     mock_app do
-      use Rack::Protection::FrameOptions, :allow_if => ->(domain){
+      use Rack::Protection::FrameOptions, :allow_if => proc {|domain|
         domain == 'google.com'
       }
       run DummyApp
@@ -48,7 +48,7 @@ describe Rack::Protection::FrameOptions do
 
   it 'should deny based on specific domain' do
     mock_app do
-      use Rack::Protection::FrameOptions, :allow_if => ->(domain){
+      use Rack::Protection::FrameOptions, :allow_if => proc {|domain|
         domain == 'yahoo.com'
       }
       run DummyApp

--- a/spec/lib/rack/protection/frame_options_spec.rb
+++ b/spec/lib/rack/protection/frame_options_spec.rb
@@ -46,4 +46,15 @@ describe Rack::Protection::FrameOptions do
     expect(get('/', {}, 'wants' => 'text/html').headers["X-Frame-Options"]).to eq("")
   end
 
+  it 'should deny based on specific domain' do
+    mock_app do
+      use Rack::Protection::FrameOptions, :allow_if => ->(domain){
+        domain == 'yahoo.com'
+      }
+      run DummyApp
+    end
+
+    expect(get('/', {}, 'wants' => 'text/html').headers["X-Frame-Options"]).to eq("DENY")
+  end
+
 end

--- a/spec/support/dummy_app.rb
+++ b/spec/support/dummy_app.rb
@@ -2,6 +2,7 @@ module DummyApp
   def self.call(env)
     Thread.current[:last_env] = env
     body = (env['REQUEST_METHOD'] == 'HEAD' ? '' : 'ok')
+    env['HTTP_REFERER'] = 'http://google.com/?q=rack%20protection'
     [200, {'Content-Type' => env['wants'] || 'text/plain'}, [body]]
   end
 end


### PR DESCRIPTION
Since `ALLOW-FROM` doesn't work properly on Chrome (and I heard Firefox), we need to be able to allow or deny being embedded based on the referrer domain. This PR adds this ability, and this is the interface of usage:

``` ruby
use Rack::Protection::FrameOptions, allow_if: ->(domain){
  domain == 'google.com'
}
```

This would allow the page to be on an iframe on google.com, and nowhere else.

WDYT?
