### PR TITLE
Fixes HttpOrigin to consider the 'null' string value

### DIFF
--- a/lib/rack/protection/http_origin.rb
+++ b/lib/rack/protection/http_origin.rb
@@ -21,8 +21,10 @@ module Rack
       end
 
       def accepts?(env)
+        origin = env['HTTP_ORIGIN']
+
         return true if safe? env
-        return true unless origin = env['HTTP_ORIGIN']
+        return true unless origin && origin != 'null'
         return true if base_url(env) == origin
         Array(options[:origin_whitelist]).include? origin
       end

--- a/spec/lib/rack/protection/http_origin_spec.rb
+++ b/spec/lib/rack/protection/http_origin_spec.rb
@@ -25,6 +25,10 @@ describe Rack::Protection::HttpOrigin do
       expect(send(method.downcase, '/', {}, 'HTTP_ORIGIN' => 'http://malicious.com')).not_to be_ok
     end
 
+    it "accepts #{} requests with 'null' Origin" do
+      expect(send(method.downcase, '/', {}, 'HTTP_ORIGIN' => 'null')).to be_ok
+    end
+
     it "accepts #{method} requests with whitelisted Origin" do
       mock_app do
         use Rack::Protection::HttpOrigin, :origin_whitelist => ['http://www.friend.com']


### PR DESCRIPTION
At least Chromium for Linux and, some version of Chrome for OSX are sending the string `null` as the value of the `HTTP_ORIGIN` header. Which is causing the `Rack::Protection::HttpOrigin` to deny the requests.

I only can test it on Linux, but I came to this from a [bug report](https://github.com/threefunkymonkeys/chist/issues/92) in one of my apps by a Google Chrome user on OSX. Here's is the output of my test requests


Chromium for Linux Version 43.0.2357.65 (64-bit)

```
From: /home/kandalf/.rvm/gems/ruby-2.1.0@chist/gems/rack-protection-1.5.2/lib/rack/protection/http_origin.rb @ line 25 Rack::Protection::HttpOrigin#accepts?:

    23: def accepts?(env)
    24: require 'pry-debugger'
 => 25: binding.pry
    26:   return true if safe? env
    27:   return true unless origin = env['HTTP_ORIGIN']
    28:   return true if base_url(env) == origin
    29:   Array(options[:origin_whitelist]).include? origin
    30: end

[1] pry(#<Rack::Protection::HttpOrigin>)> env['HTTP_USER_AGENT']
=> "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.65 Safari/537.36"
[2] pry(#<Rack::Protection::HttpOrigin>)> env['HTTP_ORIGIN']
=> "null"
[3] pry(#<Rack::Protection::HttpOrigin>)> 
```

Google Chrome for Linux Version 39.0.2171.71 (64-bit)

```
From: /home/kandalf/.rvm/gems/ruby-2.1.0@chist/gems/rack-protection-1.5.2/lib/rack/protection/http_origin.rb @ line 25 Rack::Protection::HttpOrigin#accepts?:

    23: def accepts?(env)
    24: require 'pry-debugger'
 => 25: binding.pry
    26:   return true if safe? env
    27:   return true unless origin = env['HTTP_ORIGIN']
    28:   return true if base_url(env) == origin
    29:   Array(options[:origin_whitelist]).include? origin
    30: end

[1] pry(#<Rack::Protection::HttpOrigin>)> env['HTTP_USER_AGENT']
=> "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36"
[2] pry(#<Rack::Protection::HttpOrigin>)> env['HTTP_ORIGIN']
=> "http://localhost:9292"
[3] pry(#<Rack::Protection::HttpOrigin>)> 
```

Firefox for Linux version 38.0.1

```
From: /home/kandalf/.rvm/gems/ruby-2.1.0@chist/gems/rack-protection-1.5.2/lib/rack/protection/http_origin.rb @ line 25 Rack::Protection::HttpOrigin#accepts?:

    23: def accepts?(env)
    24: require 'pry-debugger'
 => 25: binding.pry
    26:   return true if safe? env
    27:   return true unless origin = env['HTTP_ORIGIN']
    28:   return true if base_url(env) == origin
    29:   Array(options[:origin_whitelist]).include? origin
    30: end

[1] pry(#<Rack::Protection::HttpOrigin>)> env['HTTP_USER_AGENT']
=> "Mozilla/5.0 (X11; Linux x86_64; rv:38.0) Gecko/20100101 Firefox/38.0"
[2] pry(#<Rack::Protection::HttpOrigin>)> env['HTTP_ORIGIN']
=> nil
[3] pry(#<Rack::Protection::HttpOrigin>)> 
```
I'll update the version of my Google Chrome installation and I'll ask the reporter of the original bug from my app to report his version as well.   