### PR TITLE
Use secure_compare when checking CSRF token

### DIFF
--- a/lib/rack/protection/authenticity_token.rb
+++ b/lib/rack/protection/authenticity_token.rb
@@ -23,8 +23,8 @@ module Rack
         session = session env
         token   = session[:csrf] ||= session['_csrf_token'] || random_string
         safe?(env) ||
-          env['HTTP_X_CSRF_TOKEN'] == token ||
-          Request.new(env).params[options[:authenticity_param]] == token
+          secure_compare(env['HTTP_X_CSRF_TOKEN'], token) ||
+          secure_compare(Request.new(env).params[options[:authenticity_param]], token)
       end
     end
   end

--- a/lib/rack/protection/authenticity_token.rb
+++ b/lib/rack/protection/authenticity_token.rb
@@ -23,8 +23,8 @@ module Rack
         session = session env
         token   = session[:csrf] ||= session['_csrf_token'] || random_string
         safe?(env) ||
-          secure_compare(env['HTTP_X_CSRF_TOKEN'], token) ||
-          secure_compare(Request.new(env).params[options[:authenticity_param]], token)
+          secure_compare(env['HTTP_X_CSRF_TOKEN'].to_s, token) ||
+          secure_compare(Request.new(env).params[options[:authenticity_param]].to_s, token)
       end
     end
   end

--- a/lib/rack/protection/base.rb
+++ b/lib/rack/protection/base.rb
@@ -1,5 +1,4 @@
 require 'rack/protection'
-require 'rack/utils'
 require 'digest'
 require 'logger'
 require 'uri'
@@ -111,8 +110,28 @@ module Rack
         options[:encryptor].hexdigest value.to_s
       end
 
+      # The implementations of secure_compare and bytesize are taken from
+      # Rack::Utils to be able to support rack older than XXXX.
       def secure_compare(a, b)
-        Rack::Utils.secure_compare(a.to_s, b.to_s)
+        return false unless bytesize(a) == bytesize(b)
+
+        l = a.unpack("C*")
+
+        r, i = 0, -1
+        b.each_byte { |v| r |= v ^ l[i+=1] }
+        r == 0
+      end
+
+      # Return the bytesize of String; uses String#size under Ruby 1.8 and
+      # String#bytesize under 1.9.
+      if ''.respond_to?(:bytesize)
+        def bytesize(string)
+          string.bytesize
+        end
+      else
+        def bytesize(string)
+          string.size
+        end
       end
 
       alias default_reaction deny

--- a/lib/rack/protection/base.rb
+++ b/lib/rack/protection/base.rb
@@ -1,4 +1,5 @@
 require 'rack/protection'
+require 'rack/utils'
 require 'digest'
 require 'logger'
 require 'uri'
@@ -108,6 +109,10 @@ module Rack
 
       def encrypt(value)
         options[:encryptor].hexdigest value.to_s
+      end
+
+      def secure_compare(a, b)
+        Rack::Utils.secure_compare(a.to_s, b.to_s)
       end
 
       alias default_reaction deny


### PR DESCRIPTION
Since string comparisions may return early we want to use a constant
time comparsion function to protect the CSRF token against timing
attacks. Rack::Utils provides a such function.
