### PR TITLE
Fix Tempfile reference being returned as nil

### DIFF
--- a/lib/rack/protection/escaped_params.rb
+++ b/lib/rack/protection/escaped_params.rb
@@ -1,5 +1,6 @@
 require 'rack/protection'
 require 'rack/utils'
+require 'tempfile'
 
 begin
   require 'escape_utils'
@@ -66,6 +67,7 @@ module Rack
         when Hash   then escape_hash(object)
         when Array  then object.map { |o| escape(o) }
         when String then escape_string(object)
+        when Tempfile then object
         else nil
         end
       end


### PR DESCRIPTION
This PR fixes the issue of files being uploaded from users having
the params[:file][:tempfile] being returned as `nil`, rather than
an instance of Tempfile like it should be.

PR fixes #90, and shamelessly stolen from #91. This PR does
not contain the warnings that were included in #91.

Thanks for the fix @danleyden!  Hopefully this will not have a 
failing Travis.ci build.