### PR TITLE
Add :allow_if config option to http origin for custom accept/reject

### DIFF
--- a/lib/rack/protection/authenticity_token.rb
+++ b/lib/rack/protection/authenticity_token.rb
@@ -17,14 +17,17 @@ module Rack
     # authenticity_param: Defines the param's name that should contain the token on a request.
     #
     class AuthenticityToken < Base
-      default_options :authenticity_param => 'authenticity_token'
+      default_options :authenticity_param => 'authenticity_token',
+                      :allow_if => nil
 
       def accepts?(env)
         session = session env
         token   = session[:csrf] ||= session['_csrf_token'] || random_string
+
         safe?(env) ||
           env['HTTP_X_CSRF_TOKEN'] == token ||
-          Request.new(env).params[options[:authenticity_param]] == token
+          Request.new(env).params[options[:authenticity_param]] == token ||
+          ( options[:allow_if] && options[:allow_if].call(env) )
       end
     end
   end

--- a/lib/rack/protection/http_origin.rb
+++ b/lib/rack/protection/http_origin.rb
@@ -10,6 +10,7 @@ module Rack
     #
     # Does not accept unsafe HTTP requests when value of Origin HTTP request header
     # does not match default or whitelisted URIs.
+    # The :allow_if option can also be set to a proc to use custom allow/deny logic.
     class HttpOrigin < Base
       DEFAULT_PORTS = { 'http' => 80, 'https' => 443, 'coffee' => 80 }
       default_reaction :deny

--- a/lib/rack/protection/http_origin.rb
+++ b/lib/rack/protection/http_origin.rb
@@ -13,6 +13,7 @@ module Rack
     class HttpOrigin < Base
       DEFAULT_PORTS = { 'http' => 80, 'https' => 443, 'coffee' => 80 }
       default_reaction :deny
+      default_options :allow_if => nil
 
       def base_url(env)
         request = Rack::Request.new(env)
@@ -24,6 +25,7 @@ module Rack
         return true if safe? env
         return true unless origin = env['HTTP_ORIGIN']
         return true if base_url(env) == origin
+        return true if options[:allow_if] && options[:allow_if].call(env)
         Array(options[:origin_whitelist]).include? origin
       end
 

--- a/spec/lib/rack/protection/http_origin_spec.rb
+++ b/spec/lib/rack/protection/http_origin_spec.rb
@@ -20,6 +20,16 @@ describe Rack::Protection::HttpOrigin do
     end
   end
 
+  %w(GET HEAD POST PUT DELETE).each do |method|
+    it "accepts #{method} requests when allow_if is true" do
+      mock_app do
+        use Rack::Protection::HttpOrigin, :allow_if => lambda{|env| true }
+        run DummyApp
+      end
+      expect(send(method.downcase, '/', {}, 'HTTP_ORIGIN' => 'http://any.domain.com')).to be_ok
+    end
+  end
+
   %w(POST PUT DELETE).each do |method|
     it "denies #{method} requests with non-whitelisted Origin" do
       expect(send(method.downcase, '/', {}, 'HTTP_ORIGIN' => 'http://malicious.com')).not_to be_ok

--- a/spec/lib/rack/protection/http_origin_spec.rb
+++ b/spec/lib/rack/protection/http_origin_spec.rb
@@ -23,7 +23,7 @@ describe Rack::Protection::HttpOrigin do
   %w(GET HEAD POST PUT DELETE).each do |method|
     it "accepts #{method} requests when allow_if is true" do
       mock_app do
-        use Rack::Protection::HttpOrigin, :allow_if => lambda{|env| true }
+        use Rack::Protection::HttpOrigin, :allow_if => lambda{|env| env.has_key?('HTTP_ORIGIN') }
         run DummyApp
       end
       expect(send(method.downcase, '/', {}, 'HTTP_ORIGIN' => 'http://any.domain.com')).to be_ok


### PR DESCRIPTION
In my app I've got a few URL's that can be accessed from anywhere via CORS, but others should remain locked down.  

I'm handling the CORS headers on my own, but don't want to disable Rack::Protection altogether, I just need it to ignore a few endpoints

I noticed #95 also adds an `allow_if` config to FrameOptions, so I chose this name to keep them the same. 

Happy to rework as needed.

