### PR TITLE
Add img-src CSP directive

### DIFF
--- a/lib/rack/protection/content_security_policy.rb
+++ b/lib/rack/protection/content_security_policy.rb
@@ -46,7 +46,7 @@ module Rack
     class ContentSecurityPolicy < Base
       default_options :default_src => :none, :script_src => :self, :img_src => :self, :style_src => :self, :connect_src => :self, :report_only => false
 
-      KEYS = [:default_src, :script_src, :connect_src, :font_src, :frame_src, :media_src, :style_src, :object_src, :report_uri, :sandbox]
+      KEYS = [:default_src, :script_src, :connect_src, :font_src, :frame_src, :img_src, :media_src, :style_src, :object_src, :report_uri, :sandbox]
 
       def collect_options
         KEYS.collect do |k|

--- a/spec/lib/rack/protection/content_security_policy_spec.rb
+++ b/spec/lib/rack/protection/content_security_policy_spec.rb
@@ -4,7 +4,7 @@ describe Rack::Protection::ContentSecurityPolicy do
   it 'should set the Content Security Policy' do
     expect(
       get('/', {}, 'wants' => 'text/html').headers["Content-Security-Policy"]
-    ).to eq("default-src none; script-src self; connect-src self; style-src self")
+    ).to eq("default-src none; script-src self; connect-src self; img-src self; style-src self")
   end
 
   it 'should not set the Content Security Policy for other content types' do
@@ -21,7 +21,7 @@ describe Rack::Protection::ContentSecurityPolicy do
     end
 
     headers = get('/', {}, 'wants' => 'text/html').headers
-    expect(headers["Content-Security-Policy"]).to eq("default-src none; script-src https://cdn.mybank.net; connect-src https://api.mybank.com; font-src https://cdn.mybank.net; frame-src self; media-src https://cdn.mybank.net; style-src https://cdn.mybank.net; object-src https://cdn.mybank.net; report-uri /my_amazing_csp_report_parser; sandbox allow-scripts")
+    expect(headers["Content-Security-Policy"]).to eq("default-src none; script-src https://cdn.mybank.net; connect-src https://api.mybank.com; font-src https://cdn.mybank.net; frame-src self; img-src https://cdn.mybank.net; media-src https://cdn.mybank.net; style-src https://cdn.mybank.net; object-src https://cdn.mybank.net; report-uri /my_amazing_csp_report_parser; sandbox allow-scripts")
     expect(headers["Content-Security-Policy-Report-Only"]).to be_nil
   end
 
@@ -34,7 +34,7 @@ describe Rack::Protection::ContentSecurityPolicy do
 
     headers = get('/', {}, 'wants' => 'text/html').headers
     expect(headers["Content-Security-Policy"]).to be_nil
-    expect(headers["Content-Security-Policy-Report-Only"]).to eq("default-src none; script-src self; connect-src self; style-src self; report-uri /my_amazing_csp_report_parser")
+    expect(headers["Content-Security-Policy-Report-Only"]).to eq("default-src none; script-src self; connect-src self; img-src self; style-src self; report-uri /my_amazing_csp_report_parser")
   end
 
   it 'should not override the header if already set' do


### PR DESCRIPTION
It's in the list of defaults; I'm assuming it's just an oversight that
it isn't in the list of allowed KEYs