### PR TITLE
Enclose CSP self in quotes

### DIFF
--- a/lib/rack/protection/content_security_policy.rb
+++ b/lib/rack/protection/content_security_policy.rb
@@ -44,7 +44,7 @@ module Rack
     #               treated as though it was loaded inside of an iframe with
     #               a sandbox attribute.
     class ContentSecurityPolicy < Base
-      default_options :default_src => :none, :script_src => :self, :img_src => :self, :style_src => :self, :connect_src => :self, :report_only => false
+      default_options :default_src => :none, :script_src => "'self'", :img_src => "'self'", :style_src => "'self'", :connect_src => "'self'", :report_only => false
 
       KEYS = [:default_src, :script_src, :connect_src, :font_src, :frame_src, :img_src, :media_src, :style_src, :object_src, :report_uri, :sandbox]
 

--- a/spec/lib/rack/protection/content_security_policy_spec.rb
+++ b/spec/lib/rack/protection/content_security_policy_spec.rb
@@ -4,7 +4,7 @@ describe Rack::Protection::ContentSecurityPolicy do
   it 'should set the Content Security Policy' do
     expect(
       get('/', {}, 'wants' => 'text/html').headers["Content-Security-Policy"]
-    ).to eq("default-src none; script-src self; connect-src self; img-src self; style-src self")
+    ).to eq("default-src none; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'")
   end
 
   it 'should not set the Content Security Policy for other content types' do
@@ -34,7 +34,7 @@ describe Rack::Protection::ContentSecurityPolicy do
 
     headers = get('/', {}, 'wants' => 'text/html').headers
     expect(headers["Content-Security-Policy"]).to be_nil
-    expect(headers["Content-Security-Policy-Report-Only"]).to eq("default-src none; script-src self; connect-src self; img-src self; style-src self; report-uri /my_amazing_csp_report_parser")
+    expect(headers["Content-Security-Policy-Report-Only"]).to eq("default-src none; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; report-uri /my_amazing_csp_report_parser")
   end
 
   it 'should not override the header if already set' do


### PR DESCRIPTION
per https://developer.mozilla.org/en-US/docs/Web/Security/CSP/CSP_policy_directives,
the quotes are required.

See mperham/sidekiq#3070 for context.