### PR TITLE
Mitigate BREACH attack

### DIFF
--- a/lib/rack/protection/utils.rb
+++ b/lib/rack/protection/utils.rb
@@ -1,0 +1,53 @@
+require 'securerandom'
+require 'base64'
+
+module Rack
+  module Protection
+    module Utils
+
+      def random_token(length = 32)
+        SecureRandom.base64(length)
+      end
+      module_function :random_token
+
+      # Creates a masked version of the authenticity token that varies
+      # on each request. The masking is used to mitigate SSL attacks
+      # like BREACH.
+      def mask_token(token)
+        token = decode_token(token)
+        one_time_pad = SecureRandom.random_bytes(token.length)
+        encrypted_token = xor_byte_strings(one_time_pad, token)
+        masked_token = one_time_pad + encrypted_token
+        encode_token masked_token
+      end
+      module_function :mask_token
+
+      # Essentially the inverse of +mask_token+.
+      def unmask_decoded_token(masked_token)
+        # Split the token into the one-time pad and the encrypted
+        # value and decrypt it
+        token_length = masked_token.length / 2
+        one_time_pad = masked_token[0...token_length]
+        encrypted_token = masked_token[token_length..-1]
+        xor_byte_strings(one_time_pad, encrypted_token)
+      end
+      module_function :unmask_decoded_token
+
+      def encode_token(token)
+        Base64.strict_encode64(token)
+      end
+      module_function :encode_token
+
+      def decode_token(token)
+        Base64.strict_decode64(token)
+      end
+      module_function :decode_token
+
+      def xor_byte_strings(s1, s2)
+        s1.bytes.zip(s2.bytes).map { |(c1,c2)| c1 ^ c2 }.pack('c*')
+      end
+      module_function :xor_byte_strings
+
+    end
+  end
+end

--- a/spec/lib/rack/protection/authenticity_token_spec.rb
+++ b/spec/lib/rack/protection/authenticity_token_spec.rb
@@ -1,4 +1,8 @@
 describe Rack::Protection::AuthenticityToken do
+  let(:token) { Rack::Protection::Utils.random_token }
+  let(:bad_token) { Rack::Protection::Utils.random_token }
+  let(:session) { {:csrf => token} }
+
   it_behaves_like "any rack application"
 
   it "denies post requests without any token" do
@@ -6,22 +10,32 @@ describe Rack::Protection::AuthenticityToken do
   end
 
   it "accepts post requests with correct X-CSRF-Token header" do
-    post('/', {}, 'rack.session' => {:csrf => "a"}, 'HTTP_X_CSRF_TOKEN' => "a")
+    post('/', {}, 'rack.session' => session, 'HTTP_X_CSRF_TOKEN' => token)
+    expect(last_response).to be_ok
+  end
+
+  it "accepts post requests with masked X-CSRF-Token header" do
+    post('/', {}, 'rack.session' => session, 'HTTP_X_CSRF_TOKEN' => Rack::Protection::AuthenticityToken.token(session))
     expect(last_response).to be_ok
   end
 
   it "denies post requests with wrong X-CSRF-Token header" do
-    post('/', {}, 'rack.session' => {:csrf => "a"}, 'HTTP_X_CSRF_TOKEN' => "b")
+    post('/', {}, 'rack.session' => session, 'HTTP_X_CSRF_TOKEN' => bad_token)
     expect(last_response).not_to be_ok
   end
 
   it "accepts post form requests with correct authenticity_token field" do
-    post('/', {"authenticity_token" => "a"}, 'rack.session' => {:csrf => "a"})
+    post('/', {"authenticity_token" => token}, 'rack.session' => session)
+    expect(last_response).to be_ok
+  end
+
+  it "accepts post form requests with masked authenticity_token field" do
+    post('/', {"authenticity_token" => Rack::Protection::AuthenticityToken.token(session)}, 'rack.session' => session)
     expect(last_response).to be_ok
   end
 
   it "denies post form requests with wrong authenticity_token field" do
-    post('/', {"authenticity_token" => "a"}, 'rack.session' => {:csrf => "b"})
+    post('/', {"authenticity_token" => bad_token}, 'rack.session' => session)
     expect(last_response).not_to be_ok
   end
 
@@ -35,7 +49,7 @@ describe Rack::Protection::AuthenticityToken do
       run proc { |e| [200, {'Content-Type' => 'text/plain'}, ['hi']] }
     end
 
-    post('/', {"csrf_param" => "a"}, 'rack.session' => {:csrf => "a"})
+    post('/', {"csrf_param" => token}, 'rack.session' => {:csrf => token})
     expect(last_response).to be_ok
   end
 

--- a/spec/lib/rack/protection/form_token_spec.rb
+++ b/spec/lib/rack/protection/form_token_spec.rb
@@ -1,4 +1,8 @@
 describe Rack::Protection::FormToken do
+  let(:token) { Rack::Protection::Utils.random_token }
+  let(:bad_token) { Rack::Protection::Utils.random_token }
+  let(:session) { {:csrf => token} }
+
   it_behaves_like "any rack application"
 
   it "denies post requests without any token" do
@@ -6,22 +10,32 @@ describe Rack::Protection::FormToken do
   end
 
   it "accepts post requests with correct X-CSRF-Token header" do
-    post('/', {}, 'rack.session' => {:csrf => "a"}, 'HTTP_X_CSRF_TOKEN' => "a")
+    post('/', {}, 'rack.session' => session, 'HTTP_X_CSRF_TOKEN' => token)
+    expect(last_response).to be_ok
+  end
+
+  it "accepts post requests with masked X-CSRF-Token header" do
+    post('/', {}, 'rack.session' => session, 'HTTP_X_CSRF_TOKEN' => Rack::Protection::FormToken.token(session))
     expect(last_response).to be_ok
   end
 
   it "denies post requests with wrong X-CSRF-Token header" do
-    post('/', {}, 'rack.session' => {:csrf => "a"}, 'HTTP_X_CSRF_TOKEN' => "b")
+    post('/', {}, 'rack.session' => session, 'HTTP_X_CSRF_TOKEN' => bad_token)
     expect(last_response).not_to be_ok
   end
 
   it "accepts post form requests with correct authenticity_token field" do
-    post('/', {"authenticity_token" => "a"}, 'rack.session' => {:csrf => "a"})
+    post('/', {"authenticity_token" => token}, 'rack.session' => session)
+    expect(last_response).to be_ok
+  end
+
+  it "accepts post form requests with masked authenticity_token field" do
+    post('/', {"authenticity_token" => Rack::Protection::FormToken.token(session)}, 'rack.session' => session)
     expect(last_response).to be_ok
   end
 
   it "denies post form requests with wrong authenticity_token field" do
-    post('/', {"authenticity_token" => "a"}, 'rack.session' => {:csrf => "b"})
+    post('/', {"authenticity_token" => bad_token}, 'rack.session' => session)
     expect(last_response).not_to be_ok
   end
 

--- a/spec/lib/rack/protection/remote_token_spec.rb
+++ b/spec/lib/rack/protection/remote_token_spec.rb
@@ -1,4 +1,8 @@
 describe Rack::Protection::RemoteToken do
+  let(:token) { Rack::Protection::Utils.random_token }
+  let(:bad_token) { Rack::Protection::Utils.random_token }
+  let(:session) { {:csrf => token} }
+
   it_behaves_like "any rack application"
 
   it "accepts post requests with no referrer" do
@@ -16,25 +20,37 @@ describe Rack::Protection::RemoteToken do
 
   it "accepts post requests with a remote referrer and correct X-CSRF-Token header" do
     post('/', {}, 'HTTP_REFERER' => 'http://example.com/foo', 'HTTP_HOST' => 'example.org',
-      'rack.session' => {:csrf => "a"}, 'HTTP_X_CSRF_TOKEN' => "a")
+      'rack.session' => session, 'HTTP_X_CSRF_TOKEN' => token)
+    expect(last_response).to be_ok
+  end
+
+  it "accepts post requests with a remote referrer and masked X-CSRF-Token header" do
+    post('/', {}, 'HTTP_REFERER' => 'http://example.com/foo', 'HTTP_HOST' => 'example.org',
+      'rack.session' => session, 'HTTP_X_CSRF_TOKEN' => Rack::Protection::RemoteToken.token(session))
     expect(last_response).to be_ok
   end
 
   it "denies post requests with a remote referrer and wrong X-CSRF-Token header" do
     post('/', {}, 'HTTP_REFERER' => 'http://example.com/foo', 'HTTP_HOST' => 'example.org',
-      'rack.session' => {:csrf => "a"}, 'HTTP_X_CSRF_TOKEN' => "b")
+      'rack.session' => session, 'HTTP_X_CSRF_TOKEN' => bad_token)
     expect(last_response).not_to be_ok
   end
 
   it "accepts post form requests with a remote referrer and correct authenticity_token field" do
-    post('/', {"authenticity_token" => "a"}, 'HTTP_REFERER' => 'http://example.com/foo',
-      'HTTP_HOST' => 'example.org', 'rack.session' => {:csrf => "a"})
+    post('/', {"authenticity_token" => token}, 'HTTP_REFERER' => 'http://example.com/foo',
+      'HTTP_HOST' => 'example.org', 'rack.session' => session)
+    expect(last_response).to be_ok
+  end
+
+  it "accepts post form requests with a remote referrer and masked authenticity_token field" do
+    post('/', {"authenticity_token" => Rack::Protection::RemoteToken.token(session)}, 'HTTP_REFERER' => 'http://example.com/foo',
+      'HTTP_HOST' => 'example.org', 'rack.session' => session)
     expect(last_response).to be_ok
   end
 
   it "denies post form requests with a remote referrer and wrong authenticity_token field" do
-    post('/', {"authenticity_token" => "a"}, 'HTTP_REFERER' => 'http://example.com/foo',
-      'HTTP_HOST' => 'example.org', 'rack.session' => {:csrf => "b"})
+    post('/', {"authenticity_token" => bad_token}, 'HTTP_REFERER' => 'http://example.com/foo',
+      'HTTP_HOST' => 'example.org', 'rack.session' => session)
     expect(last_response).not_to be_ok
   end
 end

--- a/spec/lib/rack/protection/utils_spec.rb
+++ b/spec/lib/rack/protection/utils_spec.rb
@@ -1,0 +1,30 @@
+describe Rack::Protection::Utils do
+  let(:token) { subject.random_token }
+
+  describe "#random_token" do
+    it "outputs a base64 encoded 32 character string by default" do
+      expect(Base64.strict_decode64(token).length).to eq(32)
+    end
+
+    it "outputs a base64 encoded string of the specified length" do
+      token = subject.random_token(64)
+      expect(Base64.strict_decode64(token).length).to eq(64)
+    end
+  end
+
+  describe "#mask_token" do
+    it "generates unique masked values for a token" do
+      first_masked_token =  subject.mask_token(token)
+      second_masked_token = subject.mask_token(token)
+      expect(first_masked_token).not_to eq(second_masked_token)
+    end
+  end
+
+  describe "#unmask_decoded_token" do
+    it "unmasks a token to its original decoded value" do
+      masked_token = subject.decode_token(subject.mask_token(token))
+      unmasked_token = subject.unmask_decoded_token(masked_token)
+      expect(unmasked_token).to eq(subject.decode_token(token))
+    end
+  end
+end


### PR DESCRIPTION
Implement the Rails solution to mitigate BREACH attack. See rails/rails/pull/11729 and rails/rails/pull/16570. Resolves #64.

To actually mitigate the attack forms and meta tags will need to use a masked authenticity token. This can be retrieved by using the following:

```
Rack::Protection::AuthenticityToken.token(session)
```

In a hidden input:

```
<input type="hidden" name="authenticity_token" value="#{Rack::Protection::AuthenticityToken.token(session)}" />
```

Or in a meta tag:

```
<meta name="csrf-token" content="#{Rack::Protection::AuthenticityToken.token(session)" />
```

The `#token` method can also be called on any of the classes that extend `AuthenticityToken` such as `FormToken`, and `RemoteToken`.

Since this uses the same algorithm to mask tokens as Rails, this update will fix compatibility with with Rails >= 4.2.0.